### PR TITLE
Add typewriter effect for quiz messages

### DIFF
--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { cloudQuiz } from '@/src/config/cloudQuiz';
 import ResultCard from './ResultCard';
+import Typewriter from './Typewriter';
 
 export type Answer = { qid: string; oid: string };
 
@@ -89,7 +90,10 @@ export default function Quiz() {
 
       {phase === 'prompt' && (
         <div className="space-y-5 animate-fade-in">
-          <div className="text-slate-600">{cloudQuiz.betweenPrompts[index % cloudQuiz.betweenPrompts.length]}</div>
+          <Typewriter
+            className="text-slate-600"
+            text={cloudQuiz.betweenPrompts[index % cloudQuiz.betweenPrompts.length]}
+          />
           <button className="btn btn-ghost w-full" onClick={startQuestions}>Continue</button>
         </div>
       )}
@@ -99,7 +103,9 @@ export default function Quiz() {
           <div className="w-full h-2 bg-white/60 rounded-full overflow-hidden">
             <div className="h-full bg-sky-500" style={{ width: `${progress}%` }} />
           </div>
-          <h2 className="text-xl font-medium">{q.text}</h2>
+          <h2 className="text-xl font-medium">
+            <Typewriter text={q.text} />
+          </h2>
           <div className="grid gap-3">
             {q.options.map(opt => (
               <button key={opt.id} className="btn btn-ghost w-full text-left" onClick={() => selectOption(opt.id)}>

--- a/src/components/Typewriter.tsx
+++ b/src/components/Typewriter.tsx
@@ -1,0 +1,29 @@
+'use client';
+import React from 'react';
+
+interface TypewriterProps {
+  text: string;
+  speed?: number;
+  className?: string;
+}
+
+export default function Typewriter({ text, speed = 120, className }: TypewriterProps) {
+  const [displayed, setDisplayed] = React.useState('');
+
+  React.useEffect(() => {
+    setDisplayed('');
+    if (!text) return;
+    const words = text.split(/\s+/);
+    let i = 0;
+    const id = setInterval(() => {
+      setDisplayed(prev => prev + (i > 0 ? ' ' : '') + words[i]);
+      i++;
+      if (i >= words.length) {
+        clearInterval(id);
+      }
+    }, speed);
+    return () => clearInterval(id);
+  }, [text, speed]);
+
+  return <span className={className}>{displayed}</span>;
+}


### PR DESCRIPTION
## Summary
- animate between-question prompts and questions with a new Typewriter component
- reveal text word by word for server-like dialog

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint .` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b4ca3d3f88330bf226dcb5865a0e9