### PR TITLE
Prevent undefined word in Typewriter component

### DIFF
--- a/src/components/Typewriter.tsx
+++ b/src/components/Typewriter.tsx
@@ -16,11 +16,12 @@ export default function Typewriter({ text, speed = 120, className }: TypewriterP
     const words = text.split(/\s+/);
     let i = 0;
     const id = setInterval(() => {
-      setDisplayed(prev => prev + (i > 0 ? ' ' : '') + words[i]);
-      i++;
       if (i >= words.length) {
         clearInterval(id);
+        return;
       }
+      setDisplayed(prev => prev + (i > 0 ? ' ' : '') + words[i]);
+      i++;
     }, speed);
     return () => clearInterval(id);
   }, [text, speed]);


### PR DESCRIPTION
## Summary
- stop Typewriter interval before appending past the end of the word list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689b536c43d08330a259a4e8b709230c