### PR TITLE
feat: add dark mode toggle and animations

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,9 +7,9 @@
   --sky-2: 210 100% 90%; /* light */
   --sky-3: 210 100% 85%; /* mid */
 }
-body { @apply bg-gradient-to-b from-sky-100 to-white text-slate-800; }
+body { @apply bg-gradient-to-b from-sky-100 to-white text-slate-800 dark:from-slate-900 dark:to-slate-800 dark:text-slate-200; }
 
 .btn { @apply inline-flex items-center justify-center px-4 py-3 rounded-2xl shadow-sm active:scale-[0.99] transition; }
-.btn-primary { @apply bg-sky-600 text-white hover:bg-sky-700; }
-.btn-ghost { @apply bg-white/70 backdrop-blur border border-white/60; }
-.card { @apply rounded-3xl shadow-lg bg-white/85 backdrop-blur p-5; }
+.btn-primary { @apply bg-sky-600 text-white hover:bg-sky-700 dark:bg-sky-500 dark:hover:bg-sky-600; }
+.btn-ghost { @apply bg-white/70 backdrop-blur border border-white/60 dark:bg-slate-700/70 dark:border-slate-600; }
+.card { @apply rounded-3xl shadow-lg bg-white/85 backdrop-blur p-5 dark:bg-slate-800/80 dark:text-slate-200; }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
+import ThemeToggle from '@/src/components/ThemeToggle';
 
 export const metadata: Metadata = {
   title: 'Cloud-Type Quiz',
@@ -11,6 +12,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
+        <ThemeToggle />
         <main className="min-h-dvh flex items-stretch">{children}</main>
       </body>
     </html>

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -80,7 +80,7 @@ export default function Quiz() {
   return (
     <div className="pt-8">
       {phase === 'intro' && (
-        <div className="space-y-5">
+        <div className="space-y-5 animate-fade-in">
           <h1 className="text-3xl font-semibold text-sky-700">{cloudQuiz.intro.title}</h1>
           <p className="text-slate-600">{cloudQuiz.intro.lead}</p>
           <button className="btn btn-primary w-full" onClick={nextPrompt}>Begin</button>
@@ -99,16 +99,20 @@ export default function Quiz() {
       )}
 
       {phase === 'question' && (
-        <div className="space-y-5">
+        <div className="space-y-5 animate-fade-in">
           <div className="w-full h-2 bg-white/60 rounded-full overflow-hidden">
-            <div className="h-full bg-sky-500" style={{ width: `${progress}%` }} />
+            <div className="h-full bg-sky-500 transition-all duration-300" style={{ width: `${progress}%` }} />
           </div>
           <h2 className="text-xl font-medium">
             <Typewriter text={q.text} />
           </h2>
           <div className="grid gap-3">
             {q.options.map(opt => (
-              <button key={opt.id} className="btn btn-ghost w-full text-left" onClick={() => selectOption(opt.id)}>
+              <button
+                key={opt.id}
+                className="btn btn-ghost w-full text-left transition-transform hover:scale-[0.99]"
+                onClick={() => selectOption(opt.id)}
+              >
                 {opt.label}
               </button>
             ))}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { Sun, Moon } from 'lucide-react';
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'light'|'dark'>('light');
+  useEffect(() => {
+    const saved = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initial = saved || (prefersDark ? 'dark' : 'light');
+    setTheme(initial as any);
+    if (initial === 'dark') document.documentElement.classList.add('dark');
+  }, []);
+  const toggle = () => {
+    const next = theme === 'light' ? 'dark' : 'light';
+    setTheme(next);
+    localStorage.setItem('theme', next);
+    document.documentElement.classList.toggle('dark', next === 'dark');
+  };
+  return (
+    <button
+      onClick={toggle}
+      className="absolute top-4 right-4 p-2 rounded-full bg-white/70 dark:bg-slate-800/70 backdrop-blur shadow transition-transform hover:scale-105"
+    >
+      {theme === 'light' ? <Moon size={20}/> : <Sun size={20}/>}
+    </button>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,14 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx}",
     "./src/**/*.{js,ts,jsx,tsx}", // if you store code in /src
   ],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      keyframes: {
+        'fade-in': { from: { opacity: '0' }, to: { opacity: '1' } },
+      },
+      animation: { 'fade-in': 'fade-in 0.4s ease-out' },
+    },
+  },
   plugins: [],
+  darkMode: 'class',
 };


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode with fade-in animation
- add ThemeToggle component and integrate in layout
- improve quiz UI with dark styles, transitions, and animations

## Testing
- `npm run dev` *(fails: /usr/bin/npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca8454fe083308d329d3e8c24d6d6