### PR TITLE
feat: dark-mode sky and smoother quiz interactions

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,11 +3,16 @@
 @tailwind utilities;
 
 :root {
-  --sky-1: 210 100% 97%; /* very light */
-  --sky-2: 210 100% 90%; /* light */
-  --sky-3: 210 100% 85%; /* mid */
+  --sky-1: 210 100% 97%;
+  --sky-2: 210 100% 90%;
+  --sky-3: 210 100% 85%;
 }
-body { @apply bg-gradient-to-b from-sky-100 to-white text-slate-800 dark:from-slate-900 dark:to-slate-800 dark:text-slate-200; }
+
+/* Base page gradient + dark variant */
+body {
+  @apply bg-gradient-to-b from-sky-100 to-white text-slate-800
+         dark:from-indigo-950 dark:to-slate-900 dark:text-slate-200;
+}
 
 .btn { @apply inline-flex items-center justify-center px-4 py-3 rounded-2xl shadow-sm active:scale-[0.99] transition; }
 .btn-primary { @apply bg-sky-600 text-white hover:bg-sky-700 dark:bg-sky-500 dark:hover:bg-sky-600; }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,14 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              `(function(){try{var t=localStorage.getItem('theme');var m=window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches;var c=t||(m?'dark':'light');if(c==='dark'){document.documentElement.classList.add('dark');}}catch(e){}})();`,
+          }}
+        />
+      </head>
       <body>
         <ThemeToggle />
         <main className="min-h-dvh flex items-stretch">{children}</main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,9 +6,9 @@ export default function Page() {
   return (
     <CloudyBackdrop>
       <div className="pt-8">
-        <div className="text-center mb-4 select-none">
-          <div className="text-4xl font-bold text-sky-700">☁️ Cloud-Type</div>
-          <div className="text-sm text-slate-500">Minimal • Mobile-first • Fun</div>
+        <div className="text-center mb-8 select-none space-y-2">
+          <div className="text-5xl font-bold text-sky-700">☁️ Cloud-Type</div>
+          <div className="text-base text-slate-500 dark:text-slate-400">Minimal • Mobile-first • Fun</div>
         </div>
         <Quiz />
       </div>

--- a/src/components/CloudyBackdrop.tsx
+++ b/src/components/CloudyBackdrop.tsx
@@ -1,13 +1,50 @@
 'use client';
 import React from 'react';
 
+const stars = [
+  { top: '8%', left: '18%', size: 2 },
+  { top: '12%', left: '35%', size: 3 },
+  { top: '15%', left: '60%', size: 2 },
+  { top: '22%', left: '72%', size: 3 },
+  { top: '30%', left: '10%', size: 2 },
+  { top: '35%', left: '40%', size: 2 },
+  { top: '40%', left: '80%', size: 3 },
+  { top: '48%', left: '50%', size: 2 },
+  { top: '55%', left: '65%', size: 2 },
+  { top: '60%', left: '20%', size: 3 },
+  { top: '65%', left: '85%', size: 2 },
+  { top: '70%', left: '25%', size: 3 },
+  { top: '72%', left: '55%', size: 2 },
+  { top: '78%', left: '15%', size: 2 },
+  { top: '80%', left: '75%', size: 3 },
+  { top: '85%', left: '45%', size: 2 },
+  { top: '88%', left: '30%', size: 3 },
+  { top: '90%', left: '60%', size: 2 },
+  { top: '94%', left: '10%', size: 3 },
+  { top: '96%', left: '80%', size: 2 },
+];
+
 export default function CloudyBackdrop({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-dvh w-full bg-gradient-to-b from-sky-100 to-white">
+    <div className="min-h-dvh w-full bg-gradient-to-b from-sky-100 to-white dark:from-indigo-950 dark:to-slate-900 transition-colors duration-500">
       <div aria-hidden className="pointer-events-none fixed inset-0 overflow-hidden">
-        <div className="absolute -top-16 -left-20 w-[60vw] h-[60vw] rounded-full bg-white/70 blur-3xl" />
-        <div className="absolute top-24 right-[-10vw] w-[50vw] h-[50vw] rounded-full bg-sky-50/80 blur-3xl" />
-        <div className="absolute bottom-[-10vw] left-[-10vw] w-[55vw] h-[55vw] rounded-full bg-white/60 blur-3xl" />
+        {/* Day clouds */}
+        <div className="block dark:hidden">
+          <div className="absolute -top-24 -left-16 w-[70vw] h-[70vw] rounded-full bg-white/60 blur-3xl animate-float-x" />
+          <div className="absolute top-32 right-[-15vw] w-[60vw] h-[60vw] rounded-full bg-sky-50/80 blur-3xl animate-float-y" />
+          <div className="absolute bottom-[-10vw] left-[-10vw] w-[55vw] h-[55vw] rounded-full bg-white/60 blur-3xl animate-float-x" />
+        </div>
+        {/* Night stars */}
+        <div className="hidden dark:block">
+          {stars.map((s, i) => (
+            <div
+              key={i}
+              className="absolute bg-white/90 rounded-full animate-twinkle"
+              style={{ top: s.top, left: s.left, width: s.size, height: s.size }}
+            />
+          ))}
+          <div className="absolute -top-20 left-1/3 w-[60vw] h-[60vw] rounded-full bg-indigo-400/10 blur-3xl" />
+        </div>
       </div>
       <div className="relative z-10 px-4 pb-28 max-w-md mx-auto">{children}</div>
     </div>

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -82,16 +82,16 @@ export default function Quiz() {
       {phase === 'intro' && (
         <div className="space-y-5 animate-fade-in">
           <h1 className="text-3xl font-semibold text-sky-700">{cloudQuiz.intro.title}</h1>
-          <p className="text-slate-600">{cloudQuiz.intro.lead}</p>
+          <p className="text-slate-600 dark:text-slate-300">{cloudQuiz.intro.lead}</p>
           <button className="btn btn-primary w-full" onClick={nextPrompt}>Begin</button>
-          <p className="text-xs text-slate-500">Takes 45–60 seconds • {total} questions</p>
+          <p className="text-xs text-slate-500 dark:text-slate-400">Takes 45–60 seconds • {total} questions</p>
         </div>
       )}
 
       {phase === 'prompt' && (
         <div className="space-y-5 animate-fade-in">
           <Typewriter
-            className="text-slate-600"
+            className="text-slate-600 dark:text-slate-300"
             text={cloudQuiz.betweenPrompts[index % cloudQuiz.betweenPrompts.length]}
           />
           <button className="btn btn-ghost w-full" onClick={startQuestions}>Continue</button>
@@ -100,8 +100,8 @@ export default function Quiz() {
 
       {phase === 'question' && (
         <div className="space-y-5 animate-fade-in">
-          <div className="w-full h-2 bg-white/60 rounded-full overflow-hidden">
-            <div className="h-full bg-sky-500 transition-all duration-300" style={{ width: `${progress}%` }} />
+          <div className="w-full h-2 bg-white/60 dark:bg-slate-700/60 rounded-full overflow-hidden">
+            <div className="h-full bg-sky-500 dark:bg-sky-400 transition-all duration-300" style={{ width: `${progress}%` }} />
           </div>
           <h2 className="text-xl font-medium">
             <Typewriter text={q.text} />
@@ -110,7 +110,7 @@ export default function Quiz() {
             {q.options.map(opt => (
               <button
                 key={opt.id}
-                className="btn btn-ghost w-full text-left transition-transform hover:scale-[0.99]"
+                className="btn btn-ghost w-full text-left transition-transform hover:-translate-y-0.5"
                 onClick={() => selectOption(opt.id)}
               >
                 {opt.label}

--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -40,13 +40,13 @@ export default function ResultCard({
       <div className="card text-center">
         <div className="text-6xl">{result.emoji}</div>
         <h2 className="text-2xl font-semibold" style={{ color: result.palette.fg }}>{result.title}</h2>
-        <p className="text-slate-600 mt-2">{result.desc}</p>
+        <p className="text-slate-600 dark:text-slate-300 mt-2">{result.desc}</p>
       </div>
       <div className="grid grid-cols-2 gap-3">
         <button onClick={onShare} className="btn btn-primary w-full"><Share2 className="mr-2 h-5 w-5"/> Share</button>
         <button onClick={onDownload} className="btn btn-ghost w-full"><Download className="mr-2 h-5 w-5"/> Save</button>
       </div>
-      <div className="text-center text-xs text-slate-500">Tip: Use the Share button on mobile.</div>
+      <div className="text-center text-xs text-slate-500 dark:text-slate-400">Tip: Use the Share button on mobile.</div>
     </div>
   );
 }

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,27 +1,34 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { Sun, Moon } from 'lucide-react';
+
 export default function ThemeToggle() {
   const [theme, setTheme] = useState<'light'|'dark'>('light');
+
   useEffect(() => {
-    const saved = localStorage.getItem('theme');
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const initial = saved || (prefersDark ? 'dark' : 'light');
-    setTheme(initial as any);
-    if (initial === 'dark') document.documentElement.classList.add('dark');
+    try {
+      const saved = localStorage.getItem('theme');
+      const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+      const initial = (saved || (prefersDark ? 'dark' : 'light')) as 'light'|'dark';
+      setTheme(initial);
+      document.documentElement.classList.toggle('dark', initial === 'dark');
+    } catch {}
   }, []);
+
   const toggle = () => {
     const next = theme === 'light' ? 'dark' : 'light';
     setTheme(next);
-    localStorage.setItem('theme', next);
+    try { localStorage.setItem('theme', next); } catch {}
     document.documentElement.classList.toggle('dark', next === 'dark');
   };
+
   return (
     <button
       onClick={toggle}
+      aria-label="Toggle theme"
       className="absolute top-4 right-4 p-2 rounded-full bg-white/70 dark:bg-slate-800/70 backdrop-blur shadow transition-transform hover:scale-105"
     >
-      {theme === 'light' ? <Moon size={20}/> : <Sun size={20}/>}
+      {theme === 'light' ? <Moon size={18}/> : <Sun size={18}/>}
     </button>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,14 +6,31 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx}",
     "./src/**/*.{js,ts,jsx,tsx}", // if you store code in /src
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       keyframes: {
         'fade-in': { from: { opacity: '0' }, to: { opacity: '1' } },
+        'float-x': {
+          '0%,100%': { transform: 'translateX(0)' },
+          '50%': { transform: 'translateX(20px)' },
+        },
+        'float-y': {
+          '0%,100%': { transform: 'translateY(0)' },
+          '50%': { transform: 'translateY(-20px)' },
+        },
+        'twinkle': {
+          '0%,100%': { opacity: '0.8' },
+          '50%': { opacity: '0.2' },
+        },
       },
-      animation: { 'fade-in': 'fade-in 0.4s ease-out' },
+      animation: {
+        'fade-in': 'fade-in 0.4s ease-out',
+        'float-x': 'float-x 10s ease-in-out infinite alternate',
+        'float-y': 'float-y 12s ease-in-out infinite alternate',
+        'twinkle': 'twinkle 3s ease-in-out infinite',
+      },
     },
   },
   plugins: [],
-  darkMode: 'class',
 };


### PR DESCRIPTION
## Summary
- enable instant theme loading with inline script and ThemeToggle persistence
- add day clouds and twinkling star animations with new Tailwind keyframes
- polish quiz UI with animated progress bar, subtle button lift, and darker result card support

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive setup required, aborted)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689cb44763148330bf92cfbc4aa4a1ca